### PR TITLE
Add Connection Timeout

### DIFF
--- a/lib/socksify.rb
+++ b/lib/socksify.rb
@@ -151,7 +151,7 @@ class TCPSOCKSSocket < TCPSocket
   alias :initialize_tcp :initialize
 
   # See http://tools.ietf.org/html/rfc1928
-  def initialize(host=nil, port=0, local_host=nil, local_port=nil)
+  def initialize(host=nil, port=0, local_host=nil, local_port=nil, **kwargs)
     if host.is_a?(SOCKSConnectionPeerAddress)
       socks_peer = host
       socks_server = socks_peer.socks_server
@@ -166,7 +166,7 @@ class TCPSOCKSSocket < TCPSocket
 
     if socks_server and socks_port and not socks_ignores.include?(host)
       Socksify::debug_notice "Connecting to SOCKS server #{socks_server}:#{socks_port}"
-      initialize_tcp socks_server, socks_port
+      initialize_tcp socks_server, socks_port, **kwargs
 
       socks_authenticate unless @@socks_version =~ /^4/
 


### PR DESCRIPTION
This client is at the mercy of the SOCKS server for connection timeouts. In the event that the SOCKS server is unable to connect to the destination, the client will wait forever for the SOCKS server to indicate a failure has occurred. In certain situations, the client may want to give up and fail faster than the SOCKS server is configured to wait for. 

This PR adds an optional `:connect_timeout` option which will be passed to `TCPSocket` for the connection from the client to the SOCKS server and is also used to limit how long we wait for the SOCKS server to connect to the destination.